### PR TITLE
🔀 :: 검색 스크린 결과 아이템 중앙으로 정렬되게 변경

### DIFF
--- a/presentaion/src/main/java/com/gbs/gbs_android/view/components/BookCard.kt
+++ b/presentaion/src/main/java/com/gbs/gbs_android/view/components/BookCard.kt
@@ -20,7 +20,7 @@ import com.gbs.gbs_android.R
 fun BookCard(
     size: Dp
 ) {
-    Column() {
+    Column {
         Card(
             onClick = { /*TODO*/ },
             shape = RoundedCornerShape(10.dp),
@@ -48,5 +48,4 @@ fun BookCard(
             overflow = TextOverflow.Ellipsis
         )
     }
-
 }

--- a/presentaion/src/main/java/com/gbs/gbs_android/view/search/SearchScreen.kt
+++ b/presentaion/src/main/java/com/gbs/gbs_android/view/search/SearchScreen.kt
@@ -2,11 +2,9 @@ package com.gbs.gbs_android.view.search
 
 import android.annotation.SuppressLint
 import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
-import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
@@ -27,7 +25,7 @@ fun SearchScreen() {
         Column(
             modifier = Modifier
                 .fillMaxSize()
-                .padding(start = 18.dp, end = 18.dp, top = 30.dp)
+                .padding(start = 18.dp, end = 18.dp, top = 30.dp),
         ) {
             SearchTextField(
                 hint = "책 이름, 저자, 출판사 등",
@@ -36,17 +34,23 @@ fun SearchScreen() {
             )
 
             val list = listOf(1,2,3,4,5,6,7,8,9,10)     // test data(추후에 서버 데이터로 교체 예정)
-            LazyVerticalGrid(columns = GridCells.Fixed(2), modifier = Modifier.padding(top = 30.dp)) {
+            LazyVerticalGrid(
+                columns = GridCells.Fixed(2),
+                modifier = Modifier
+                    .padding(top = 30.dp)
+                    .fillMaxWidth()
+            ) {
                 items(list) {
-                    BookCard(size = 170.dp)
+                    // 아이템의 가로 비율을 같게 해주는 Box.
+                    Box(
+                        modifier = Modifier
+                            .padding(start = 16.dp, end = 16.dp)
+                            .fillMaxSize()
+                    ) {
+                        BookCard(size = 200.dp)     // 가로의 크기는 고정되어 있어서 높이만 변경된다.
+                    }
                 }
             }       // 추후 추가 예정
         }
     }
-}
-
-@Preview
-@Composable
-fun SearchPreview() {
-    SearchScreen()
 }


### PR DESCRIPTION
# 변경 내용
검색 결과의 아이템의 크기가 작아도 중앙으로 정렬되게 변경

# 결과
![image](https://user-images.githubusercontent.com/84944117/229667228-330e752f-170f-43b4-a78d-3aa3939b4991.png)